### PR TITLE
Update util_class.py

### DIFF
--- a/functions/crux/util_class.py
+++ b/functions/crux/util_class.py
@@ -14,22 +14,29 @@ class Crux:
         self.crux_table = crux_table
         self.bigquery = bigquery
         self.storage_client = storage_client
-
-    def table_suffix(self):
-
-        today = datetime.date.today()
-        first = today.replace(day=1)
-        lastMonth = first - datetime.timedelta(days=1)
-        return lastMonth.strftime("%Y%m")
-
+    
     def check_rows(self):
 
         table = self.bigquery_client.get_table(self.crux_table)
         return table.num_rows
 
+
+    def table_suffix(self):
+
+        minus_days = 1
+        if(self.check_rows() == 0):
+            minus_days = 32
+        today = datetime.date.today()
+        first = today.replace(day=1)
+        lastMonth = first - datetime.timedelta(days=minus_days)
+        return lastMonth.strftime("%Y%m")
+
+    
+
     def check_table_crux(self):
         try:
             full_table = "chrome-ux-report.all." + self.table_suffix()
+            query_job = self.bigquery_client.get_table(full_table)
             return True
 
         except NotFound:


### PR DESCRIPTION
A line of code that checks the existence of the crux tables was missing from the last master update.

**What issue does this pull request resolve?**
The crux function was unable to check the availability of the crux public tables. This pull request resolves this issue.
**What changes did you make?**
I've changed the util_class.py: Crux.check_table_crux() and Crux.table_suffix().
**Is there anything that requires more attention while reviewing?**
No.